### PR TITLE
Change lsb0 functionality for bitstring v4

### DIFF
--- a/src/dumpling/Chips/Rosetta.py
+++ b/src/dumpling/Chips/Rosetta.py
@@ -21,7 +21,7 @@ import bitstring
 import click
 from dumpling.Common.ElfParser import ElfParser
 from bitstring import BitArray
-bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 from dumpling.Common.HP93000 import HP93000VectorWriter
 from dumpling.JTAGTaps.PulpJTAGTapRosetta import PULPJTagTapRosetta
 from dumpling.Common.VectorBuilder import VectorBuilder

--- a/src/dumpling/Chips/Siracusa.py
+++ b/src/dumpling/Chips/Siracusa.py
@@ -22,7 +22,7 @@ import bitstring
 import click
 from dumpling.Common.ElfParser import ElfParser
 from bitstring import BitArray
-bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 from dumpling.Common.HP93000 import HP93000VectorWriter
 from dumpling.JTAGTaps.PulpJTAGTap import PULPJtagTap
 from dumpling.Common.VectorBuilder import VectorBuilder

--- a/src/dumpling/Chips/Vega.py
+++ b/src/dumpling/Chips/Vega.py
@@ -21,7 +21,7 @@ import bitstring
 import click
 from dumpling.Common.ElfParser import ElfParser
 from bitstring import BitArray
-bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 from dumpling.Common.HP93000 import HP93000VectorWriter
 from dumpling.JTAGTaps.PulpJTAGTapVega import PULPJtagTapVega
 from dumpling.Common.VectorBuilder import VectorBuilder

--- a/src/dumpling/Drivers/JTAG.py
+++ b/src/dumpling/Drivers/JTAG.py
@@ -18,7 +18,7 @@ from bitstring import BitArray
 
 from dumpling.JTAGTaps.JTAGTap import JTAGTap, JTAGRegister
 
-bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 from dumpling.Common.VectorBuilder import VectorBuilder
 
 class JTAGDriver:

--- a/src/dumpling/JTAGTaps/PulpJTAGTap.py
+++ b/src/dumpling/JTAGTaps/PulpJTAGTap.py
@@ -21,7 +21,7 @@ from dumpling.Common.ElfParser import ElfParser
 from dumpling.Common.VectorBuilder import VectorBuilder
 from dumpling.Drivers.JTAG import JTAGTap, JTAGDriver, JTAGRegister
 from bitstring import BitArray
-bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 
 
 class PULPJtagTap(JTAGTap):

--- a/src/dumpling/JTAGTaps/PulpJTAGTapRosetta.py
+++ b/src/dumpling/JTAGTaps/PulpJTAGTapRosetta.py
@@ -17,7 +17,7 @@ from dumpling.Drivers.JTAG import JTAGDriver, JTAGRegister
 from dumpling.JTAGTaps.PulpJTAGTap import PULPJtagTap
 import bitstring
 from bitstring import BitArray
-bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 
 
 class PULPJTagTapRosetta(PULPJtagTap):

--- a/src/dumpling/JTAGTaps/PulpJTAGTapVega.py
+++ b/src/dumpling/JTAGTaps/PulpJTAGTapVega.py
@@ -21,7 +21,7 @@ from dumpling.Common.ElfParser import ElfParser
 from dumpling.Common.VectorBuilder import VectorBuilder
 from dumpling.Drivers.JTAG import JTAGTap, JTAGDriver, JTAGRegister
 from bitstring import BitArray
-bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 
 
 class PULPJtagTapVega(JTAGTap):

--- a/src/dumpling/JTAGTaps/RISCVDebugTap.py
+++ b/src/dumpling/JTAGTaps/RISCVDebugTap.py
@@ -20,7 +20,7 @@ import bitstring
 from dumpling.Common.VectorBuilder import VectorBuilder
 from dumpling.Drivers.JTAG import JTAGDriver, JTAGRegister, JTAGTap
 from bitstring import BitArray
-bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 
 class DMIOp(Enum):
     NOP = '00'


### PR DESCRIPTION
When attempting to run dumpling from a fresh install, the following error occurred.
```
  File "/***/dumpling/Chips/Rosetta.py", line 24, in <module>
    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
AttributeError: module 'bitstring' has no attribute 'set_lsb0'
```
Upon closer investigation (also with the corresponding link), the newer version of the bitstring (v4) seems to be causing the issue, I hope the fix introduced works as intended.