### PR TITLE
Ensure backwards-compatibility of bitstring lsb0

### DIFF
--- a/src/dumpling/Chips/Rosetta.py
+++ b/src/dumpling/Chips/Rosetta.py
@@ -21,7 +21,10 @@ import bitstring
 import click
 from dumpling.Common.ElfParser import ElfParser
 from bitstring import BitArray
-bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+if (int(bitstring.__version__[0]) < 4):
+    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+else:
+    bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 from dumpling.Common.HP93000 import HP93000VectorWriter
 from dumpling.JTAGTaps.PulpJTAGTapRosetta import PULPJTagTapRosetta
 from dumpling.Common.VectorBuilder import VectorBuilder

--- a/src/dumpling/Chips/Siracusa.py
+++ b/src/dumpling/Chips/Siracusa.py
@@ -22,7 +22,10 @@ import bitstring
 import click
 from dumpling.Common.ElfParser import ElfParser
 from bitstring import BitArray
-bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+if (int(bitstring.__version__[0]) < 4):
+    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+else:
+    bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 from dumpling.Common.HP93000 import HP93000VectorWriter
 from dumpling.JTAGTaps.PulpJTAGTap import PULPJtagTap
 from dumpling.Common.VectorBuilder import VectorBuilder

--- a/src/dumpling/Chips/Vega.py
+++ b/src/dumpling/Chips/Vega.py
@@ -21,7 +21,10 @@ import bitstring
 import click
 from dumpling.Common.ElfParser import ElfParser
 from bitstring import BitArray
-bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+if (int(bitstring.__version__[0]) < 4):
+    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+else:
+    bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 from dumpling.Common.HP93000 import HP93000VectorWriter
 from dumpling.JTAGTaps.PulpJTAGTapVega import PULPJtagTapVega
 from dumpling.Common.VectorBuilder import VectorBuilder

--- a/src/dumpling/Drivers/JTAG.py
+++ b/src/dumpling/Drivers/JTAG.py
@@ -18,7 +18,10 @@ from bitstring import BitArray
 
 from dumpling.JTAGTaps.JTAGTap import JTAGTap, JTAGRegister
 
-bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+if (int(bitstring.__version__[0]) < 4):
+    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+else:
+    bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 from dumpling.Common.VectorBuilder import VectorBuilder
 
 class JTAGDriver:

--- a/src/dumpling/JTAGTaps/PulpJTAGTap.py
+++ b/src/dumpling/JTAGTaps/PulpJTAGTap.py
@@ -21,7 +21,10 @@ from dumpling.Common.ElfParser import ElfParser
 from dumpling.Common.VectorBuilder import VectorBuilder
 from dumpling.Drivers.JTAG import JTAGTap, JTAGDriver, JTAGRegister
 from bitstring import BitArray
-bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+if (int(bitstring.__version__[0]) < 4):
+    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+else:
+    bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 
 
 class PULPJtagTap(JTAGTap):

--- a/src/dumpling/JTAGTaps/PulpJTAGTapRosetta.py
+++ b/src/dumpling/JTAGTaps/PulpJTAGTapRosetta.py
@@ -17,7 +17,10 @@ from dumpling.Drivers.JTAG import JTAGDriver, JTAGRegister
 from dumpling.JTAGTaps.PulpJTAGTap import PULPJtagTap
 import bitstring
 from bitstring import BitArray
-bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+if (int(bitstring.__version__[0]) < 4):
+    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+else:
+    bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 
 
 class PULPJTagTapRosetta(PULPJtagTap):

--- a/src/dumpling/JTAGTaps/PulpJTAGTapVega.py
+++ b/src/dumpling/JTAGTaps/PulpJTAGTapVega.py
@@ -21,7 +21,10 @@ from dumpling.Common.ElfParser import ElfParser
 from dumpling.Common.VectorBuilder import VectorBuilder
 from dumpling.Drivers.JTAG import JTAGTap, JTAGDriver, JTAGRegister
 from bitstring import BitArray
-bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+if (int(bitstring.__version__[0]) < 4):
+    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+else:
+    bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 
 
 class PULPJtagTapVega(JTAGTap):

--- a/src/dumpling/JTAGTaps/RISCVDebugTap.py
+++ b/src/dumpling/JTAGTaps/RISCVDebugTap.py
@@ -20,7 +20,10 @@ import bitstring
 from dumpling.Common.VectorBuilder import VectorBuilder
 from dumpling.Drivers.JTAG import JTAGDriver, JTAGRegister, JTAGTap
 from bitstring import BitArray
-bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+if (int(bitstring.__version__[0]) < 4):
+    bitstring.set_lsb0(True) #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
+else:
+    bitstring.lsb0 = True #Enables the experimental mode to index LSB with 0 instead of the MSB (see thread https://github.com/scott-griffiths/bitstring/issues/156)
 
 class DMIOp(Enum):
     NOP = '00'


### PR DESCRIPTION
As some systems currently still have an older version of bitstring installed, this commit allows newer versions of dumpling to be backward-compatible with older bitstring versions.